### PR TITLE
Update nodejs.md

### DIFF
--- a/docs/containers/nodejs.md
+++ b/docs/containers/nodejs.md
@@ -7,4 +7,4 @@ You can configure Node.js via environment variables that listed at https://githu
 Usage:
 
 1. Install [Node.js Integration Drupal module](https://www.drupal.org/project/nodejs) on your site
-2. Visit the Node.js configuration page under the Configuration menu, and enter the connection information for your Node.js server application. Set host to `node` and service key can be found on `[Instance] > Stack > Node.js`
+2. Visit the Node.js configuration page under the Configuration menu, and enter the connection information for your Node.js server application. Set host to `nodejs` and service key can be found on `[Instance] > Stack > Node.js`


### PR DESCRIPTION
The correct host is `nodejs`, not `node`.

I only managed to run drupal-nodejs bridge with Drupal 7 by set host in settings to `nodejs`, not `node`.

![screenshot_20180619_181015](https://user-images.githubusercontent.com/2356744/41599230-067f09a4-73ec-11e8-8977-d81ed98371be.png)

![screenshot_20180619_181033](https://user-images.githubusercontent.com/2356744/41599251-12066c04-73ec-11e8-83ef-0e873e1f9ef0.png)
